### PR TITLE
Error logging for various file operaitions. This will help a lot if some...

### DIFF
--- a/GitCandy/Git/Cache/GitCacheAccessor.cs
+++ b/GitCandy/Git/Cache/GitCacheAccessor.cs
@@ -299,7 +299,10 @@ namespace GitCandy.Git.Cache
                         }
                     }
                 }
-                catch { }
+                catch (Exception ex) {
+                    Logger.Error("GitCacheAccess Load error");
+                    Logger.Error(ex.ToString());
+                }
             }
             return false;
         }

--- a/GitCandy/Git/ContributorsAccessor.cs
+++ b/GitCandy/Git/ContributorsAccessor.cs
@@ -59,7 +59,7 @@ namespace GitCandy.Git
                         statistics.Contributors++;
                     }
                 }
-                var size = 0;
+                long size = 0;
                 statistics.Files = FilesInCommit(commit, out size);
                 statistics.SourceSize = size;
 
@@ -74,7 +74,7 @@ namespace GitCandy.Git
             }
         }
 
-        private int FilesInCommit(Commit commit, out int sourceSize)
+        private int FilesInCommit(Commit commit, out long sourceSize)
         {
             var count = 0;
             var stack = new Stack<Tree>();

--- a/GitCandy/Git/GitService.cs
+++ b/GitCandy/Git/GitService.cs
@@ -676,13 +676,19 @@ namespace GitCandy.Git
                 }
                 return true;
             }
-            catch
+            catch (Exception ex)
             {
+                Logger.Error("CreateRepository error");
+                Logger.Error(ex.ToString());
                 try
                 {
                     Directory.Delete(path, true);
                 }
-                catch { }
+                catch (Exception ex2)
+                {
+                    Logger.Error("CreateRepository Directory Delete error");
+                    Logger.Error(ex2.ToString());
+                }
                 return false;
             }
         }
@@ -692,19 +698,23 @@ namespace GitCandy.Git
             var path = Path.Combine(UserConfiguration.Current.RepositoryPath, name);
             var temp = Path.Combine(UserConfiguration.Current.RepositoryPath, name + "." + DateTime.Now.Ticks + ".del");
 
-            var retry = 3;
-            for (; retry > 0; retry--)
+            var retryLimit = 3;
+            var retry1 = retryLimit;
+            for (; retry1 > 0; retry1--)
                 try
                 {
                     Directory.Move(path, temp);
                     break;
                 }
-                catch
+                catch (Exception ex)
                 {
+                    Logger.Error("CreateRepository Directory Move error");
+                    Logger.Error(ex.ToString());
                     Task.Delay(1000).Wait();
                 }
 
-            for (; retry > 0; retry--)
+            var retry2 = retryLimit;
+            for (; retry2 > 0; retry2--)
                 try
                 {
                     var di = new DirectoryInfo(temp);
@@ -714,23 +724,28 @@ namespace GitCandy.Git
 
                     break;
                 }
-                catch
+                catch (Exception ex)
                 {
+                    Logger.Error("CreateRepository DirectoryInfo error");
+                    Logger.Error(ex.ToString());
                     Task.Delay(1000).Wait();
                 }
 
-            for (; retry > 0; retry--)
+            var retry3 = retryLimit;
+            for (; retry3 > 0; retry3--)
                 try
                 {
                     Directory.Delete(temp, true);
                     break;
                 }
-                catch
+                catch (Exception ex)
                 {
+                    Logger.Error("CreateRepository Directory Delete error (inner)");
+                    Logger.Error(ex.ToString());
                     Task.Delay(1000).Wait();
                 }
 
-            return retry > 0;
+            return retry1 > 0 || retry2 > 0 || retry3 > 0;
         }
 
         public static DirectoryInfo GetDirectoryInfo(string project)
@@ -790,8 +805,10 @@ namespace GitCandy.Git
                     return output.StartsWith("git version");
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                Logger.Error("VerifyGit error");
+                Logger.Error(ex.ToString());
                 return false;
             }
         }

--- a/GitCandy/Models/RepositoryStatisticsModel.cs
+++ b/GitCandy/Models/RepositoryStatisticsModel.cs
@@ -14,7 +14,7 @@ namespace GitCandy.Models
             public string Branch { get; set; }
             public int Files { get; set; }
             public int Commits { get; set; }
-            public int SourceSize { get; set; }
+            public long SourceSize { get; set; }
             public int Contributors { get; set; }
         }
     }

--- a/GitCandy/packages.config
+++ b/GitCandy/packages.config
@@ -4,7 +4,7 @@
   <package id="bootstrap" version="2.3.2" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.0" targetFramework="net45" />
   <package id="jQuery" version="2.0.3" targetFramework="net45" />
-  <package id="LibGit2Sharp" version="0.15.0.0" targetFramework="net45" />
+  <package id="LibGit2Sharp" version="0.21.0.176" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.2" targetFramework="net45" />


### PR DESCRIPTION
...one looks into the log of a deployed instance.

(I'm tracking down an issue where both on my Win 8.1 dev box and both on a Server 2012 box, where GitCandy cannot create a repo when it is deployed. With theses error logging I'm investigating this:

04/11/2015 13:46:37.964 -07:00 Error, LibGit2Sharp.NameConflictException: Failed to make directory 'c:/Users/Csaba/Documents': Cannot create a file when that file already exists.

   at LibGit2Sharp.Core.Ensure.HandleError(Int32 result)
   at LibGit2Sharp.Core.Proxy.git_repository_init_ext(FilePath workdirPath, FilePath gitdirPath, Boolean isBare)
   at LibGit2Sharp.Repository.Init(String path, Boolean isBare)
   at GitCandy.Git.GitService.CreateRepository(String name)

My Repositoriesdirectory settings points to c:/Users/Csaba/Documents/GCD/Repositories/ and when I start GitCandy from debugger in an IIS Express, it works.)
